### PR TITLE
cleaned up flake8 complaints

### DIFF
--- a/dicom_event_broker_adapter/ups_event_mqtt_broker_adapter.py
+++ b/dicom_event_broker_adapter/ups_event_mqtt_broker_adapter.py
@@ -31,7 +31,7 @@ logging.basicConfig()
 
 ADAPTER_AE_TITLE = "UPSEventBroker01"
 broker_address: str = "127.0.0.1"  # use loopback as a default
-broker_port: int = 1833  # default MQTT port
+broker_port: int = 1883  # default MQTT port
 
 event_type_dict = {
     1: "UPS State Report",
@@ -123,8 +123,7 @@ def process_mqtt_message(this_client: mqtt_client.Client, userdata: Any, message
             uid = parts[2]
             if uid in [UPSGlobalSubscriptionInstance, UPSFilteredGlobalSubscriptionInstance]:
                 event_type = 0
-                action_type = 3  # subscribe
-                action_type = 4  # unsubscribe
+                action_type = 4  # unsubscribe - only the last assignment has effect
             else:
                 ups_uid = uid
                 if len(parts) > 3:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,15 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from pydicom import Dataset
-from pynetdicom.events import Event
-from pynetdicom.sop_class import (
-    UnifiedProcedureStepEvent,
-    UnifiedProcedureStepPush,
-    UnifiedProcedureStepWatch,
-    UPSFilteredGlobalSubscriptionInstance,
-    UPSGlobalSubscriptionInstance,
-    Verification,
-)
+from pynetdicom.sop_class import UnifiedProcedureStepPush, UPSGlobalSubscriptionInstance
 
 
 @pytest.fixture

--- a/tests/test_dimse_handlers.py
+++ b/tests/test_dimse_handlers.py
@@ -1,10 +1,9 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 # Import helpers from conftest.py
 from conftest import create_dimse_n_action_mock
-from pydicom import Dataset
 
 from dicom_event_broker_adapter.ups_event_mqtt_broker_adapter import handle_echo, handle_n_action
 
@@ -58,4 +57,3 @@ class TestDIMSEHandlers:
     @pytest.mark.skip(reason="This test is too complex to mock correctly")
     def test_handle_n_action_unsubscribe(self):
         """Placeholder for N-ACTION unsubscribe test (skipped due to complexity)."""
-        pass

--- a/tests/test_dimse_n_event.py
+++ b/tests/test_dimse_n_event.py
@@ -1,8 +1,6 @@
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 # Import helpers from conftest.py
 from conftest import create_dimse_n_event_mock
 

--- a/tests/test_dimse_server.py
+++ b/tests/test_dimse_server.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
 from pynetdicom import AE
 from pynetdicom.sop_class import UnifiedProcedureStepEvent, UnifiedProcedureStepPush, UnifiedProcedureStepWatch, Verification
 
@@ -15,7 +14,7 @@ class TestDIMSEServer:
         listening_port = 11119
 
         # Mock the event handlers
-        mock_handlers = [(1, "handle_n_action"), (2, "handle_n_event"), (3, "handle_echo")]
+        # mock_handlers = [(1, "handle_n_action"), (2, "handle_n_event"), (3, "handle_echo")]
         mock_evt.EVT_N_ACTION = 1
         mock_evt.EVT_N_EVENT_REPORT = 2
         mock_evt.EVT_C_ECHO = 3

--- a/tests/test_load_ae_config.py
+++ b/tests/test_load_ae_config.py
@@ -1,9 +1,5 @@
 import json
-import os
-from pathlib import Path
 from unittest.mock import mock_open, patch
-
-import pytest
 
 from dicom_event_broker_adapter.ups_event_mqtt_broker_adapter import load_ae_config
 

--- a/tests/test_mqtt_functions.py
+++ b/tests/test_mqtt_functions.py
@@ -1,8 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
-
-from dicom_event_broker_adapter.ups_event_mqtt_broker_adapter import Command, register_subscriber, unregister_subscriber
+from dicom_event_broker_adapter.ups_event_mqtt_broker_adapter import register_subscriber, unregister_subscriber
 
 
 class TestMQTTFunctions:


### PR DESCRIPTION
intended to address #7

## Summary by Sourcery

This PR includes several fixes and improvements. It adds a test case for processing MQTT messages with invalid topics, ensuring that no event report is sent for such topics. It also corrects the default MQTT port number and removes unused imports and commented-out code in the tests.

Tests:
- Adds a test case to verify that no event report is sent when processing MQTT messages with invalid topics.
- Removes unused imports from test_mqtt_functions.py