### PR TITLE
add integration tests with mosquitto, including locally run, locally via docker, and in the CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,7 +23,7 @@ jobs:
         ports:
           - 1883:1883
         volumes:
-          - ${{ github.workspace }}/tests/config/mosquitto.conf:/mosquitto/config/mosquitto.conf
+          - ${{ github.workspace }}/tests/config/:/mosquitto/config/
         options: >-
           --health-cmd "timeout 5 mosquitto_sub -t test/topic -C 1 -E -v"
           --health-interval 10s

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,6 +17,19 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      mosquitto:
+        image: eclipse-mosquitto:2.0
+        ports:
+          - 1883:1883
+        volumes:
+          - ${{ github.workspace }}/tests/config/mosquitto.conf:/mosquitto/config/mosquitto.conf
+        options: >-
+          --health-cmd "timeout 5 mosquitto_sub -t test/topic -C 1 -E -v"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.10
@@ -61,6 +74,10 @@ jobs:
         # --extend-ignore=203 because black puts in a space before a slicing :
         # while flake8 complains (this warning is not PEP 8 compliant), If W503 pops up, that should be disabled also
         poetry run flake8 --count --extend-ignore=E203 --max-line-length=127 --statistics dicom_event_broker_adapter
-    - name: Test with pytest
+    - name: Run unit tests with pytest
       run: |
-        poetry run pytest tests
+        poetry run pytest tests --ignore=tests/test_mqtt_integration.py
+
+    - name: Run integration tests with real Mosquitto
+      run: |
+        poetry run pytest tests/test_mqtt_integration.py -v

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,8 +22,6 @@ jobs:
         image: eclipse-mosquitto:2.0
         ports:
           - 1883:1883
-        volumes:
-          - ${{ github.workspace }}/tests/config:/mosquitto/config
         options: >-
           --health-cmd "mosquitto_sub -t test/topic -C 1 -E -v || exit 1"
           --health-interval 10s
@@ -74,10 +72,15 @@ jobs:
         # --extend-ignore=203 because black puts in a space before a slicing :
         # while flake8 complains (this warning is not PEP 8 compliant), If W503 pops up, that should be disabled also
         poetry run flake8 --count --extend-ignore=E203 --max-line-length=127 --statistics dicom_event_broker_adapter
-    - name: Verify Mosquitto config file is available
+    - name: Create and copy Mosquitto config
       run: |
+        docker exec $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0") sh -c "mkdir -p /mosquitto/config"
+        docker cp ${{ github.workspace }}/tests/config/mosquitto.conf $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0"):/mosquitto/config/
         docker exec $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0") ls -la /mosquitto/config/
         docker exec $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0") cat /mosquitto/config/mosquitto.conf
+        # Restart mosquitto to use the new config
+        docker exec $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0") sh -c "pkill mosquitto || true"
+        docker exec $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0") sh -c "mosquitto -c /mosquitto/config/mosquitto.conf -d"
 
     - name: Run unit tests with pytest
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -74,13 +74,14 @@ jobs:
         poetry run flake8 --count --extend-ignore=E203 --max-line-length=127 --statistics dicom_event_broker_adapter
     - name: Create and copy Mosquitto config
       run: |
-        docker exec $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0") sh -c "mkdir -p /mosquitto/config"
-        docker cp ${{ github.workspace }}/tests/config/mosquitto.conf $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0"):/mosquitto/config/
-        docker exec $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0") ls -la /mosquitto/config/
-        docker exec $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0") cat /mosquitto/config/mosquitto.conf
+        CONTAINER_ID=$(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0")
+        docker exec ${CONTAINER_ID} sh -c "mkdir -p /mosquitto/config"
+        docker cp ${{ github.workspace }}/tests/config/mosquitto.conf ${CONTAINER_ID}:/mosquitto/config/
+        docker exec ${CONTAINER_ID} ls -la /mosquitto/config/
+        docker exec ${CONTAINER_ID} cat /mosquitto/config/mosquitto.conf
         # Restart mosquitto to use the new config
-        docker exec $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0") sh -c "pkill mosquitto || true"
-        docker exec $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0") sh -c "mosquitto -c /mosquitto/config/mosquitto.conf -d"
+        docker exec ${CONTAINER_ID} sh -c "pkill mosquitto || true"
+        docker exec ${CONTAINER_ID} sh -c "mosquitto -c /mosquitto/config/mosquitto.conf -d"
 
     - name: Run unit tests with pytest
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,9 +23,9 @@ jobs:
         ports:
           - 1883:1883
         volumes:
-          - ${{ github.workspace }}/tests/config/:/mosquitto/config/
+          - ${{ github.workspace }}/tests/config:/mosquitto/config
         options: >-
-          --health-cmd "timeout 5 mosquitto_sub -t test/topic -C 1 -E -v"
+          --health-cmd "mosquitto_sub -t test/topic -C 1 -E -v || exit 1"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -74,6 +74,11 @@ jobs:
         # --extend-ignore=203 because black puts in a space before a slicing :
         # while flake8 complains (this warning is not PEP 8 compliant), If W503 pops up, that should be disabled also
         poetry run flake8 --count --extend-ignore=E203 --max-line-length=127 --statistics dicom_event_broker_adapter
+    - name: Verify Mosquitto config file is available
+      run: |
+        docker exec $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0") ls -la /mosquitto/config/
+        docker exec $(docker ps -q --filter "ancestor=eclipse-mosquitto:2.0") cat /mosquitto/config/mosquitto.conf
+
     - name: Run unit tests with pytest
       run: |
         poetry run pytest tests --ignore=tests/test_mqtt_integration.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,16 @@
 
 ## Commands
 - Install dependencies: `poetry install`
+- Run unit tests: `poetry run pytest tests --ignore=tests/test_mqtt_integration.py`
+- Run integration tests: `poetry run pytest tests/test_mqtt_integration.py -v`
+- Run tests with specific marker: `poetry run pytest -m mqtt_integration`
 - Run all tests: `poetry run pytest tests`
 - Run specific test: `poetry run pytest tests/test_file.py::TestClass::test_method`
 - Lint code: `poetry run flake8 dicom_event_broker_adapter`
 - Format code: `poetry run black dicom_event_broker_adapter`
 - Sort imports: `poetry run isort dicom_event_broker_adapter`
+- Start Mosquitto for testing: `./scripts/run_mosquitto.sh start`
+- Stop Mosquitto after testing: `./scripts/run_mosquitto.sh stop`
 
 ## Code Style
 - Follow Black formatting (line length: 127)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # dicom_event_broker_adapter
-Adapter between DICOM UPS Watch and Event and Event Brokers, such as mosquitto and solace (at this point, any MQTT broker supporting 3.1.1)
+Adapter between DICOM UPS Watch and Event and Event Brokers, such as Mosquitto and Solace (at this point, any MQTT broker supporting 3.1.1)
 
 The first adapter is for DIMSE and MQTT over TCP using python.
 
@@ -50,7 +50,7 @@ Integration tests require a running Mosquitto MQTT broker. You can run these tes
     ./scripts/run_mosquitto.sh status
     ```
 
-You can also run all tests (both unit and integration) if Mosquitto is running:
+If Mosquitto is running, the following command will execute all tests (both unit and integration). If Mosquitto is not running, only the unit tests will be executed:
 
     poetry run pytest tests
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,51 @@ Future adapters will hopefully include adaptation for DICOM Web (UPS-RS) and to 
 
     poetry install
 
+## Testing
+
+### Unit Tests
+
+Run the unit tests with:
+
+    poetry run pytest tests --ignore=tests/test_mqtt_integration.py
+
+### Integration Tests
+
+Integration tests require a running Mosquitto MQTT broker. You can run these tests by:
+
+1. Start the Mosquitto broker:
+
+    ```
+    ./scripts/run_mosquitto.sh start
+    ```
+
+    The script will try to use:
+    - An existing Mosquitto broker if one is already running on port 1883
+    - Docker to run Mosquitto in a container
+    - A locally installed Mosquitto if Docker is not available
+
+2. Run the integration tests:
+
+    ```
+    poetry run pytest tests/test_mqtt_integration.py -v
+    ```
+
+3. Stop the Mosquitto broker when done:
+
+    ```
+    ./scripts/run_mosquitto.sh stop
+    ```
+
+4. Check Mosquitto status:
+
+    ```
+    ./scripts/run_mosquitto.sh status
+    ```
+
+You can also run all tests (both unit and integration) if Mosquitto is running:
+
+    poetry run pytest tests
+
 ## Command-Line Interface
 
 The DICOM Event Broker Adapter can be run from the command line after installation. Here's how to use it:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    mqtt_integration: mark a test as requiring a real MQTT broker
+testpaths =
+    tests

--- a/scripts/run_mosquitto.sh
+++ b/scripts/run_mosquitto.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+
+# Script to start/stop Mosquitto for local testing
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+MOSQUITTO_CONFIG="$REPO_ROOT/tests/config/mosquitto.conf"
+CONTAINER_NAME="mqtt-test-broker"
+PID_FILE="/tmp/mqtt-test-broker.pid"
+
+is_port_in_use() {
+    if command -v nc &> /dev/null; then
+        nc -z localhost 1883 &> /dev/null
+        return $?
+    elif command -v lsof &> /dev/null; then
+        lsof -i:1883 &> /dev/null
+        return $?
+    else
+        # Default to assuming port is not in use if we can't check
+        return 1
+    fi
+}
+
+start_mosquitto() {
+    echo "Starting Mosquitto broker for testing..."
+
+    # Check if mosquitto is already running on port 1883
+    if is_port_in_use; then
+        echo "⚠️  Port 1883 is already in use. A Mosquitto broker might already be running."
+        echo "✅ Using existing broker on localhost:1883"
+        return 0
+    fi
+
+    # Try Docker first
+    if command -v docker &> /dev/null; then
+        echo "Using Docker to run Mosquitto..."
+
+        # Check if container already exists
+        if docker ps -a --format '{{.Names}}' | grep -q "^$CONTAINER_NAME$"; then
+            echo "Mosquitto container already exists, stopping and removing it first..."
+            docker stop "$CONTAINER_NAME" &> /dev/null
+            docker rm "$CONTAINER_NAME" &> /dev/null
+        fi
+
+        # Start new container
+        docker run -d --name "$CONTAINER_NAME" \
+            -p 1883:1883 \
+            -v "$MOSQUITTO_CONFIG:/mosquitto/config/mosquitto.conf" \
+            eclipse-mosquitto:2.0
+
+        echo "Waiting for Mosquitto to start..."
+        sleep 2
+
+        if docker ps | grep -q "$CONTAINER_NAME"; then
+            echo "✅ Mosquitto broker is running on localhost:1883 via Docker"
+            return 0
+        else
+            echo "⚠️  Failed to start Mosquitto via Docker"
+            docker logs "$CONTAINER_NAME" 2>/dev/null || true
+            # Fall through to try local mosquitto
+        fi
+    else
+        echo "Docker is not available. Checking for local Mosquitto installation..."
+    fi
+
+    # Try local Mosquitto as fallback
+    if command -v mosquitto &> /dev/null; then
+        echo "Found local Mosquitto installation, launching directly..."
+
+        # Simpler approach - just start mosquitto as a daemon
+        # Check if config file exists and is readable
+        if [ -f "$MOSQUITTO_CONFIG" ] && [ -r "$MOSQUITTO_CONFIG" ]; then
+            echo "Configuration file exists and is readable"
+            # Display config file content for debugging
+            echo "Configuration file content:"
+            cat "$MOSQUITTO_CONFIG"
+        else
+            echo "⚠️  Configuration file not found or not readable, will use default config"
+            MOSQUITTO_CONFIG=""
+        fi
+
+        # Kill any existing Mosquitto processes first to avoid port conflicts
+        pkill mosquitto 2>/dev/null || true
+        sleep 1
+
+        # Start Mosquitto with the config file if it's valid
+        if [ -n "$MOSQUITTO_CONFIG" ]; then
+            echo "Starting with config file: $MOSQUITTO_CONFIG"
+            mosquitto -c "$MOSQUITTO_CONFIG" -d
+        else
+            echo "Starting with default config"
+            mosquitto -d
+        fi
+
+        echo "Waiting for Mosquitto to start..."
+        sleep 2
+
+        # Check if mosquitto is running by checking the port
+        if is_port_in_use; then
+            # Find the PID of the mosquitto process
+            MOSQUITTO_PID=$(pgrep mosquitto)
+            if [ -n "$MOSQUITTO_PID" ]; then
+                echo $MOSQUITTO_PID > "$PID_FILE"
+                echo "✅ Mosquitto broker is running on localhost:1883 (PID: $MOSQUITTO_PID)"
+                return 0
+            else
+                echo "⚠️  Port is open but couldn't find Mosquitto PID"
+                return 0  # Still return success as broker is running
+            fi
+        else
+            echo "❌ Failed to start local Mosquitto"
+            return 1
+        fi
+    else
+        echo "❌ Neither Docker nor local Mosquitto installation found."
+        echo "Please install Docker or Mosquitto to run integration tests."
+        return 1
+    fi
+}
+
+stop_mosquitto() {
+    echo "Stopping Mosquitto broker..."
+
+    # Try to stop Docker container if it exists
+    if command -v docker &> /dev/null && docker ps | grep -q "$CONTAINER_NAME" 2>/dev/null; then
+        echo "Stopping Docker container..."
+        docker stop "$CONTAINER_NAME" &> /dev/null
+        docker rm "$CONTAINER_NAME" &> /dev/null
+        echo "✅ Mosquitto Docker container stopped"
+        return 0
+    fi
+
+    # First check for any Mosquitto process running locally
+    if pgrep mosquitto >/dev/null; then
+        echo "Found running Mosquitto process(es), stopping them..."
+
+        # Use PID file if it exists
+        if [ -f "$PID_FILE" ]; then
+            MOSQUITTO_PID=$(cat "$PID_FILE")
+            if kill -0 "$MOSQUITTO_PID" 2>/dev/null; then
+                echo "Stopping local Mosquitto process (PID: $MOSQUITTO_PID)..."
+                kill "$MOSQUITTO_PID" 2>/dev/null
+            fi
+            rm -f "$PID_FILE"
+        fi
+
+        # Use pkill as a fallback to kill all mosquitto processes
+        pkill mosquitto 2>/dev/null
+        sleep 1
+
+        # Verify it's stopped
+        if pgrep mosquitto >/dev/null; then
+            echo "⚠️  Failed to stop Mosquitto gracefully, trying SIGKILL..."
+            pkill -9 mosquitto 2>/dev/null
+            sleep 1
+        fi
+
+        # Final check
+        if ! pgrep mosquitto >/dev/null; then
+            echo "✅ Local Mosquitto process(es) stopped"
+            return 0
+        else
+            echo "⚠️  Some Mosquitto processes could not be stopped. You may need to stop them manually."
+        fi
+    elif [ -f "$PID_FILE" ]; then
+        echo "⚠️  PID file exists but no Mosquitto process is running"
+        rm -f "$PID_FILE"
+    else
+        echo "No Mosquitto processes found"
+    fi
+
+    # Check if port 1883 is still in use
+    if is_port_in_use; then
+        echo "⚠️  Port 1883 is still in use by another process."
+        echo "You may need to stop it manually."
+    else
+        echo "✅ No MQTT broker running on port 1883"
+    fi
+}
+
+case "$1" in
+    start)
+        if ! start_mosquitto; then
+            echo "Failed to start Mosquitto. Integration tests requiring MQTT will be skipped."
+            exit 1
+        fi
+        ;;
+    stop)
+        stop_mosquitto
+        ;;
+    restart)
+        stop_mosquitto
+        if ! start_mosquitto; then
+            echo "Failed to restart Mosquitto. Integration tests requiring MQTT will be skipped."
+            exit 1
+        fi
+        ;;
+    status)
+        if is_port_in_use; then
+            echo "✅ Mosquitto broker is running on localhost:1883"
+            exit 0
+        else
+            echo "❌ No Mosquitto broker is running on localhost:1883"
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|status}"
+        exit 1
+        ;;
+esac

--- a/scripts/run_mosquitto.sh
+++ b/scripts/run_mosquitto.sh
@@ -43,9 +43,20 @@ start_mosquitto() {
         fi
 
         # Start new container
+        # Ensure config file exists
+        if [ ! -f "$MOSQUITTO_CONFIG" ]; then
+            echo "⚠️ Config file not found: $MOSQUITTO_CONFIG"
+            exit 1
+        fi
+
+        echo "Using config from: $MOSQUITTO_CONFIG"
+
+        # Create a directory to hold the config if needed
+        CONFIG_DIR=$(dirname "$MOSQUITTO_CONFIG")
+
         docker run -d --name "$CONTAINER_NAME" \
             -p 1883:1883 \
-            -v "$MOSQUITTO_CONFIG:/mosquitto/config/mosquitto.conf" \
+            -v "$MOSQUITTO_CONFIG:/mosquitto/config/mosquitto.conf:ro" \
             eclipse-mosquitto:2.0
 
         echo "Waiting for Mosquitto to start..."

--- a/tests/config/mosquitto.conf
+++ b/tests/config/mosquitto.conf
@@ -1,0 +1,4 @@
+listener 1883
+allow_anonymous true
+persistence false
+log_type all

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,32 @@
 Common fixtures and utilities for tests.
 """
 import json
+import socket
 from unittest.mock import MagicMock, patch
 
 import pytest
 from pydicom import Dataset
 from pynetdicom.sop_class import UnifiedProcedureStepPush, UPSGlobalSubscriptionInstance
+
+
+def pytest_configure(config):
+    """Configure pytest with custom markers."""
+    config.addinivalue_line("markers", "mqtt_integration: mark test as requiring a real MQTT broker")
+
+
+def is_port_open(host, port):
+    """Check if a port is open."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(1)
+    result = sock.connect_ex((host, port))
+    sock.close()
+    return result == 0
+
+
+# Skip if Mosquitto is not running
+mqtt_integration = pytest.mark.skipif(
+    not is_port_open("localhost", 1883), reason="Mosquitto broker not available on localhost:1883"
+)
 
 
 @pytest.fixture

--- a/tests/test_mqtt_integration.py
+++ b/tests/test_mqtt_integration.py
@@ -1,0 +1,102 @@
+"""Integration tests using a real MQTT broker (Mosquitto)."""
+
+import time
+
+import pytest
+from conftest import mqtt_integration
+from paho.mqtt import client as mqtt_client
+
+from dicom_event_broker_adapter.ups_event_mqtt_broker_adapter import _construct_mqtt_topic
+
+
+@pytest.mark.mqtt_integration
+class TestMQTTIntegration:
+    """Test integration with real MQTT broker."""
+
+    @pytest.fixture
+    def mqtt_client(self):
+        """Create and connect an MQTT client."""
+        broker = "localhost"
+        port = 1883
+        client_id = f"python-mqtt-test-{time.time()}"
+
+        def on_connect(client, userdata, flags, rc, properties=None):
+            if rc == 0:
+                print("Connected to MQTT Broker!")
+            else:
+                print(f"Failed to connect, return code {rc}")
+
+        client = mqtt_client.Client(callback_api_version=mqtt_client.CallbackAPIVersion.VERSION2, client_id=client_id)
+        client.on_connect = on_connect
+
+        try:
+            client.connect(broker, port)
+            client.loop_start()
+
+            # Allow time to connect
+            time.sleep(0.2)
+
+            if not client.is_connected():
+                pytest.skip("Could not connect to MQTT broker at localhost:1883")
+
+            yield client
+        except Exception as e:
+            pytest.skip(f"Failed to connect to MQTT broker: {e}")
+        finally:
+            if client.is_connected():
+                client.loop_stop()
+                client.disconnect()
+
+    def test_publish_and_receive(self, mqtt_client):
+        """Test publishing a message and receiving it."""
+        # Arrange
+        topic = "test/topic"
+        test_message = "Hello MQTT"
+        received_messages = []
+
+        def on_message(client, userdata, msg, properties=None):
+            received_messages.append(msg.payload.decode())
+
+        mqtt_client.subscribe(topic)
+        mqtt_client.on_message = on_message
+
+        # Act
+        result = mqtt_client.publish(topic, test_message)
+
+        # Allow time for message to be received
+        time.sleep(0.5)
+
+        # Assert
+        assert result.rc == 0  # MQTT_ERR_SUCCESS
+        assert len(received_messages) == 1
+        assert received_messages[0] == test_message
+
+    def test_construct_topic_for_workitem(self, mqtt_client):
+        """Test constructing a topic for a workitem."""
+        # Arrange
+        received_messages = []
+        event_type = "Workitem"
+        workitem_uid = "1.2.3.4.5"
+        workitem_subtopic = "state"
+        expected_topic = f"/workitems/{workitem_uid}/{workitem_subtopic}"
+        test_message = "UPS State Change Event"
+
+        def on_message(client, userdata, msg, properties=None):
+            received_messages.append({"topic": msg.topic, "payload": msg.payload.decode()})
+
+        mqtt_client.subscribe("/workitems/#")
+        mqtt_client.on_message = on_message
+
+        # Act
+        topic = _construct_mqtt_topic(event_type=event_type, workitem_uid=workitem_uid, workitem_subtopic=workitem_subtopic)
+        result = mqtt_client.publish(topic, test_message)
+
+        # Allow time for message to be received
+        time.sleep(0.5)
+
+        # Assert
+        assert topic == expected_topic
+        assert result.rc == 0  # MQTT_ERR_SUCCESS
+        assert len(received_messages) == 1
+        assert received_messages[0]["topic"] == expected_topic
+        assert received_messages[0]["payload"] == test_message

--- a/tests/test_mqtt_integration.py
+++ b/tests/test_mqtt_integration.py
@@ -63,8 +63,11 @@ class TestMQTTIntegration:
         # Act
         result = mqtt_client.publish(topic, test_message)
 
-        # Allow time for message to be received
-        time.sleep(0.5)
+        # Wait for message to be received using a polling mechanism
+        timeout = 2
+        start_time = time.time()
+        while time.time() - start_time < timeout and len(received_messages) < 1:
+            time.sleep(0.1)
 
         # Assert
         assert result.rc == 0  # MQTT_ERR_SUCCESS

--- a/tests/test_mqtt_integration.py
+++ b/tests/test_mqtt_integration.py
@@ -66,7 +66,7 @@ class TestMQTTIntegration:
         # Wait for message to be received using a polling mechanism
         timeout = 2
         start_time = time.time()
-        while time.time() - start_time < timeout and len(received_messages) < 1:
+        while time.time() - start_time < timeout and not received_messages:
             time.sleep(0.1)
 
         # Assert


### PR DESCRIPTION
## Summary by Sourcery

Adds integration tests with a Mosquitto MQTT broker, which can be run locally, via Docker, or in CI. The tests verify the adapter's ability to publish and receive messages.

Tests:
- Adds integration tests for MQTT functionality, including publishing and subscribing to topics.
- Adds a pytest marker to identify tests that require a running MQTT broker.
- Adds a fixture to check if the MQTT broker is running before running integration tests.
- Adds a configuration file for Mosquitto to be used in the tests.
- Adds a test to verify the construction of MQTT topics for workitems.
- Adds a test to verify the publishing and receiving of messages to the MQTT broker.