### PR TITLE
consolidates duplicate repo entries for uv hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,9 +27,4 @@ repos:
     rev: 0.6.6
     hooks:
       - id: uv-lock
-
-  - repo: https://github.com/astral-sh/uv-pre-commit
-    # uv version.
-    rev: 0.6.6
-    hooks:
       - id: uv-export


### PR DESCRIPTION
intended to close issue #27

## Summary by Sourcery

Consolidate duplicate repository entries for uv hooks in the pre-commit configuration file.