### PR TITLE
Fix workflow repo permissions

### DIFF
--- a/.github/workflows/claude_code_workflow.yml
+++ b/.github/workflows/claude_code_workflow.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   run-claude-code:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # This allows writing to the repository (creating commits/branches)
+      pull-requests: write  # This allows creating PRs
     environment: ClaudeCodeFixes
     # Only run when issues contain the "ai-fix" label or on manual dispatch
     if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.issue.labels.*.name, 'ai-fix') }}
@@ -24,6 +27,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0  # This is important for operations that need git history
+
+      - name: Setup GitHub credentials for PR creation
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
 
       - name: Set up environment
         run: |


### PR DESCRIPTION
## Summary by Sourcery

Grant write permissions to the 'contents' and 'pull-requests' for the workflow, allowing it to create commits, branches, and pull requests. Configure Git to use the GITHUB_TOKEN for authentication and set the user name and email for commit authorship.

CI:
- Grant write permissions to the 'contents' and 'pull-requests' for the workflow.
- Configure Git to use the GITHUB_TOKEN for authentication and set the user name and email for commit authorship.