### PR TITLE
specify /dev/null for prompt-file, i.e. the file specified to have th…

### DIFF
--- a/.github/workflows/claude_code_workflow.yml
+++ b/.github/workflows/claude_code_workflow.yml
@@ -97,6 +97,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           prompt: ${{ inputs.prompt }}
+          prompt-file: "/dev/null"
           acknowledge-dangerously-skip-permissions-responsibility: "true"
 
       # Comment on issue with Claude's response


### PR DESCRIPTION
…e bug in it, if one wasn't specified.

The shell script generated as input to the claude code action is failing and this might be a hack around that.

## Summary by Sourcery

CI:
- Specify /dev/null for prompt-file in the claude code workflow.