### PR TITLE
Claude fix claude workflow

### DIFF
--- a/.github/workflows/claude_code_workflow.yml
+++ b/.github/workflows/claude_code_workflow.yml
@@ -73,9 +73,8 @@ jobs:
           # github.repository_owner failed for some reason, only static strings for uses?
         # uses: ${{ github.repository_owner }}/claude-code-action@main
         uses: sjswerdloff/claude-code-action@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ env.PROMPT }}
           acknowledge-dangerously-skip-permissions-responsibility: "true"
 
@@ -83,9 +82,8 @@ jobs:
       - name: Run Claude Code (manual with file)
         if: github.event_name == 'workflow_dispatch' && env.FILE_EXISTS == 'true'
         uses: sjswerdloff/claude-code-action@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ inputs.prompt }}
           prompt-file: prompt_file.txt
           acknowledge-dangerously-skip-permissions-responsibility: "true"
@@ -93,9 +91,8 @@ jobs:
       - name: Run Claude Code (manual without file)
         if: github.event_name == 'workflow_dispatch' && (env.FILE_EXISTS != 'true' || inputs.file_path == '')
         uses: sjswerdloff/claude-code-action@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ inputs.prompt }}
           prompt-file: "/dev/null"
           acknowledge-dangerously-skip-permissions-responsibility: "true"


### PR DESCRIPTION
passing GitHub token through inputs rather than environment

## Summary by Sourcery

CI:
- Passes the GitHub token to the Claude Code Action through the action's inputs instead of environment variables.