### PR TITLE
get workflow to act on a label change.

### DIFF
--- a/.github/workflows/claude_code_workflow.yml
+++ b/.github/workflows/claude_code_workflow.yml
@@ -2,7 +2,7 @@ name: Claude Code Assistant
 
 on:
   issues:
-    types: [opened, edited]
+    types: [opened, edited, labeled]
   workflow_dispatch:
     inputs:
       prompt:


### PR DESCRIPTION
Given that the trigger depends on the label, it should happen when there is a label change

## Summary by Sourcery

CI:
- The workflow now triggers on the 'labeled' event for issues.