### PR TITLE
switching to storing the issue body in a file and passing that as an input.

### DIFF
--- a/.github/workflows/claude_code_workflow.yml
+++ b/.github/workflows/claude_code_workflow.yml
@@ -41,6 +41,18 @@ jobs:
         run: |
           echo "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}" >> $GITHUB_ENV
 
+      - name: Save issue body to file
+        uses: actions/github-script@v6
+        # Write the issue body directly to a file
+        # complex issue content blows up when put in the environment
+        # and when placed on a command line
+        with:
+          script: |
+            const fs = require('fs');
+            const issueBody = context.payload.issue.body;
+            fs.writeFileSync('issue_body.txt', issueBody);
+            console.log('Issue body saved to file successfully');
+
       # For issue events
       - name: Prepare prompt from issue
         if: github.event_name == 'issues'
@@ -49,12 +61,11 @@ jobs:
           echo "ISSUE_TITLE=${{ github.event.issue.title }}" >> $GITHUB_ENV
           echo "ISSUE_NUMBER=${{ github.event.issue.number }}" >> $GITHUB_ENV
 
-          # Use GitHub's special delimiter syntax for multi-line values
-          cat << 'PROMPTDELIMITER' >> $GITHUB_ENV
-          PROMPT<<ENDOFPROMPT
-          ${{ toJSON(github.event.issue.body) }}
-          ENDOFPROMPT
-          PROMPTDELIMITER
+          # put the issue title and number in the prompt
+          echo "PROMPT<<EOF" >> $GITHUB_ENV
+          echo "${{ github.event.issue.number }}" >> $GITHUB_ENV
+          echo "${{ github.event.issue.title }}" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
           echo "Analyzing issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
 
@@ -86,6 +97,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ env.PROMPT }}
+          prompt-file: issue_body.txt
           acknowledge-dangerously-skip-permissions-responsibility: "true"
 
       # Run Claude Code with manual input


### PR DESCRIPTION
storing the issue body in a file using github script action rather than the shell. shell has problems with compelx content in the issue body. putting the issue number and issue title in the prompt

## Summary by Sourcery

Refactor the workflow to store the issue body in a file and pass it as input to the Claude Code action. This change addresses issues with complex content in the issue body when using the shell.

CI:
- Store the issue body in a file using the github-script action to handle complex content.
- Pass the issue number and title in the prompt.