### PR TITLE
using PAT generated for claude code action to use for PR

### DIFF
--- a/.github/workflows/claude_code_workflow.yml
+++ b/.github/workflows/claude_code_workflow.yml
@@ -23,6 +23,8 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.issue.labels.*.name, 'ai-fix') }}
     env:
       REPO_OWNER: ${{ github.repository_owner }}
+      # Make the PAT available to the action
+      CLAUDE_CODE_FIX_PR_PAT: ${{ secrets.CLAUDE_CODE_FIX_PR_PAT }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Make the PAT available to the Claude code action.