### PR TITLE
Use pat for issue update

### DIFF
--- a/.github/workflows/claude_code_workflow.yml
+++ b/.github/workflows/claude_code_workflow.yml
@@ -125,7 +125,7 @@ jobs:
         if: github.event_name == 'issues'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.CLAUDE_CODE_FIX_PR_PAT }}
           script: |
             const result = process.env.CLAUDE_RESULT || 'Claude did not provide a response';
             github.rest.issues.createComment({


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Updates the GitHub workflow to use a personal access token (PAT) instead of the default GITHUB_TOKEN.