### PR TITLE
ci: add kindled-mqtt-notify.yml to provide event driven notification …

### DIFF
--- a/.github/workflows/kindled-mqtt-notify.yml
+++ b/.github/workflows/kindled-mqtt-notify.yml
@@ -1,0 +1,77 @@
+# kindled-mqtt-notify.yml
+# Publishes GitHub PR lifecycle events to The Kindled MQTT bus, mirroring the
+# Gitea->MQTT grammar (grammar_version: 1). The runner joins the tailnet via an
+# ephemeral Tailscale node, then publishes directly to the broker at 100.96.61.20:1883.
+# No public ingress; nothing is exposed to the internet.
+#
+# Authored by vivian-1a61bc9a. Requires one repo (or org) secret: TS_AUTHKEY.
+# The mapping logic here is verified locally against sample GitHub events; see
+# github-mqtt-bridge/map_event.sh + test/ in vivian-1a61bc9a's home dir.
+
+name: kindled-mqtt-notify
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Join the tailnet (ephemeral node)
+        uses: tailscale/github-action@v3
+        with:
+          authkey: ${{ secrets.TS_AUTHKEY }}
+          # If your tailnet ACLs are locked down, tag the ephemeral runner and
+          # grant that tag access to the broker host on tcp:1883. Example:
+          #   tags: tag:ci
+          version: latest
+
+      - name: Install mosquitto client
+        run: sudo apt-get update && sudo apt-get install -y mosquitto-clients
+
+      - name: Build grammar payload and publish
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          # Pass the whole event as JSON via env (avoids shell-injection from titles etc.)
+          GH_EVENT: ${{ toJSON(github.event) }}
+          BROKER: 100.96.61.20
+          PORT: "1883"
+        run: |
+          set -euo pipefail
+          ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          body="$GH_EVENT"
+
+          pct() { local s="$1"; s="${s//%/%25}"; s="${s//\//%2F}"; s="${s//+/%2B}"; s="${s//\#/%23}"; s="${s// /%20}"; printf '%s' "$s"; }
+
+          action="$(jq -r '.action // ""' <<<"$body")"
+          repo="$(jq -r '.repository.full_name' <<<"$body")"
+          pr="$(jq -r '.pull_request.number // .number' <<<"$body")"
+          head_sha="$(jq -r '.pull_request.head.sha // ""' <<<"$body")"
+          actor="$(jq -r '.sender.login // ""' <<<"$body")"
+          merged="$(jq -r '.pull_request.merged // false' <<<"$body")"
+
+          case "$GH_EVENT_NAME:$action" in
+            pull_request:opened|pull_request:reopened) event="opened" ;;
+            pull_request:synchronize)                  event="synchronized" ;;
+            pull_request:closed) [ "$merged" = "true" ] && event="merged" || event="closed" ;;
+            pull_request_review:submitted)             event="reviewed" ;;
+            *) echo "unsurfaced action $GH_EVENT_NAME:$action — nothing to publish"; exit 0 ;;
+          esac
+
+          terminal=false; case "$event" in merged|closed) terminal=true ;; esac
+          enc_repo="$(pct "$repo")"
+          payload="$(jq -cn --argjson gv 1 --arg e "$event" --arg r "$repo" --argjson pr "$pr" \
+            --arg hs "$head_sha" --arg a "$actor" --arg ts "$ts" --argjson term "$terminal" \
+            '{grammar_version:$gv, event:$e, repo:$r, pr:$pr, head_sha:$hs, actor:$a, ts:$ts, terminal:$term}')"
+
+          base="kindled/github/repo/${enc_repo}/pr/${pr}"
+          echo "Publishing $event -> $base"
+          # Event pulse (not retained) + status snapshot (retained), both qos 1 — mirrors the Gitea bridge.
+          mosquitto_pub -h "$BROKER" -p "$PORT" -q 1 -t "${base}/${event}" -m "$payload"
+          mosquitto_pub -h "$BROKER" -p "$PORT" -q 1 -r -t "${base}/status" -m "$payload"

--- a/.github/workflows/kindled-mqtt-notify.yml
+++ b/.github/workflows/kindled-mqtt-notify.yml
@@ -1,10 +1,22 @@
 # kindled-mqtt-notify.yml
 # Publishes GitHub PR lifecycle events to The Kindled MQTT bus, mirroring the
 # Gitea->MQTT grammar (grammar_version: 1). The runner joins the tailnet via an
-# ephemeral Tailscale node, then publishes directly to the broker at 100.96.61.20:1883.
+# ephemeral Tailscale node, then publishes directly to the broker over the tailnet.
 # No public ingress; nothing is exposed to the internet.
 #
-# Authored by vivian-1a61bc9a. Requires one repo (or org) secret: TS_AUTHKEY.
+# Authored by vivian-1a61bc9a.
+#
+# Required repo (or org) SECRETS:
+#   TS_OAUTH_CLIENT_ID  - Tailscale OAuth client id
+#   TS_OAUTH_SECRET     - Tailscale OAuth client secret (scope: auth_keys, write)
+# Required repo (or org) VARIABLES:
+#   KINDLED_BROKER_HOST - MQTT broker address on the tailnet
+#   KINDLED_BROKER_PORT - optional, defaults to 1883
+#
+# OAuth replaces the older TS_AUTHKEY: auth keys expire after at most 90 days and
+# would take the bridge down silently; OAuth clients do not. OAuth clients are not
+# associated with a tailnet user, so `tags:` below is MANDATORY, not optional.
+#
 # The mapping logic here is verified locally against sample GitHub events; see
 # github-mqtt-bridge/map_event.sh + test/ in vivian-1a61bc9a's home dir.
 
@@ -24,12 +36,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Join the tailnet (ephemeral node)
-        uses: tailscale/github-action@v3
+        uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
-          # If your tailnet ACLs are locked down, tag the ephemeral runner and
-          # grant that tag access to the broker host on tcp:1883. Example:
-          #   tags: tag:ci
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          # REQUIRED with OAuth: the client is not a tailnet user, so it must tag
+          # its nodes. tag:github-ci must be granted access to the broker host on
+          # tcp:1883 in the tailnet ACL, and owned via tagOwners.
+          tags: tag:github-ci
           version: latest
 
       - name: Install mosquitto client
@@ -40,13 +54,26 @@ jobs:
           GH_EVENT_NAME: ${{ github.event_name }}
           # Pass the whole event as JSON via env (avoids shell-injection from titles etc.)
           GH_EVENT: ${{ toJSON(github.event) }}
-          BROKER: 100.96.61.20
-          PORT: "1883"
+          BROKER: ${{ vars.KINDLED_BROKER_HOST }}
+          PORT: ${{ vars.KINDLED_BROKER_PORT }}
         run: |
           set -euo pipefail
+
+          # Fail loudly on a missing broker rather than letting mosquitto_pub fail
+          # obscurely — an unset variable should not look like a delivery problem.
+          : "${BROKER:?KINDLED_BROKER_HOST repository variable is not set}"
+          : "${PORT:=1883}"
+
           ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           body="$GH_EVENT"
 
+          # Topic encoding. GitHub restricts owner and repo names to [A-Za-z0-9._-],
+          # joined by '/', so within a valid repository.full_name the only characters
+          # needing encoding are the MQTT topic separator '/' and the wildcards '+'
+          # and '#'. '%' is encoded first so the mapping stays reversible; ' ' is
+          # covered as belt-and-braces though it is not a legal GitHub name character.
+          # This set is sufficient *because* of that constraint — so the constraint is
+          # asserted below rather than assumed.
           pct() { local s="$1"; s="${s//%/%25}"; s="${s//\//%2F}"; s="${s//+/%2B}"; s="${s//\#/%23}"; s="${s// /%20}"; printf '%s' "$s"; }
 
           action="$(jq -r '.action // ""' <<<"$body")"
@@ -65,6 +92,17 @@ jobs:
           esac
 
           terminal=false; case "$event" in merged|closed) terminal=true ;; esac
+
+          # Assert the constraint that makes pct() sufficient. If GitHub ever permits a
+          # character outside this set, refuse rather than publish to a mangled topic --
+          # a wrong topic delivers silently to nobody, which is indistinguishable from
+          # a working bridge with no events.
+          case "$repo" in
+            *[!A-Za-z0-9._/-]*)
+              echo "::error::repository.full_name '$repo' contains characters outside [A-Za-z0-9._/-]; refusing to publish to a possibly-mangled topic. Widen pct() deliberately rather than loosening this check."
+              exit 1 ;;
+          esac
+
           enc_repo="$(pct "$repo")"
           payload="$(jq -cn --argjson gv 1 --arg e "$event" --arg r "$repo" --argjson pr "$pr" \
             --arg hs "$head_sha" --arg a "$actor" --arg ts "$ts" --argjson term "$terminal" \


### PR DESCRIPTION
…to Kindled who are subscribed

## Summary by Sourcery

CI:
- Introduce kindled-mqtt-notify workflow to emit PR and review events to an internal MQTT broker via Tailscale.